### PR TITLE
Patch: Quigley was a bad reviewer

### DIFF
--- a/web/models/groups.ex
+++ b/web/models/groups.ex
@@ -18,7 +18,7 @@ defmodule Thegm.Groups do
     has_many :group_members, Thegm.GroupMembers
     has_many :join_requests, Thegm.GroupJoinRequests
     has_many :blocked_users, Thegm.GroupBlockedUsers
-    
+
 
     timestamps()
   end
@@ -42,7 +42,7 @@ defmodule Thegm.Groups do
   def create_changeset(model, params \\ :empty) do
     model
     |> changeset(params)
-    |> lat_lon
+    |> lat_lng
     |> cast(%{id: generate_uuid(params["slug"])}, [:id])
   end
 


### PR DESCRIPTION
In the last pull request instances of `lon` became `lng`. This included the function `lat_lon` becoming `lat_lng`. However, where the function was called from still referred to the function as `lat_lon`. Also, apparently I changed some whitespace.