### PR TITLE
Allow the frontend to determine the uuids for GET requests

### DIFF
--- a/web/controllers/groups_controller.ex
+++ b/web/controllers/groups_controller.ex
@@ -119,10 +119,9 @@ defmodule Thegm.GroupsController do
     end
   end
 
-  def show(conn, %{"id" => group_slug}) do
-    group_id = Groups.generate_uuid(group_slug)
-
+  def show(conn, %{"id" => group_id}) do
     user_id = conn.assigns[:current_user].id
+    
     case Repo.get(Groups, group_id) |> Repo.preload([{:group_members, :users}]) do
       nil ->
         conn

--- a/web/controllers/users_controller.ex
+++ b/web/controllers/users_controller.ex
@@ -31,8 +31,7 @@ defmodule Thegm.UsersController do
     end
   end
 
-  def show(conn, %{"username" => username}) do
-    user_id = Users.generate_uuid(username)
+  def show(conn, %{"id" => user_id}) do
     current_user_id = conn.assigns[:current_user].id
 
     case Repo.get(Users, user_id) |> Repo.preload([{:group_members, :groups}]) do

--- a/web/router.ex
+++ b/web/router.ex
@@ -13,7 +13,7 @@ defmodule Thegm.Router do
     pipe_through [:api, :auth]
 
     get "/rolldice", RollDiceController, :index
-    get "/users/:username", UsersController, :show
+    get "/users/:id", UsersController, :show
     get "/users", UsersController, :index
     post "/logout", SessionsController, :delete
     resources "/groups", GroupsController, except: [:edit, :new]


### PR DESCRIPTION
There was a miscommunication on the UUIDv5 implementation. The API will still assume UUIDs for resource requests. The frontend will either have the UUID already to make the request or will be able to calculate it from the user's username or the group's slug.