### PR TITLE
Fix group creation failing and member_status not returning correct value

### DIFF
--- a/web/controllers/groups_controller.ex
+++ b/web/controllers/groups_controller.ex
@@ -23,9 +23,10 @@ defmodule Thegm.GroupsController do
         case Repo.transaction(multi) do
           {:ok, result} ->
             group = Repo.preload(result.groups, [{:group_members, :users}])
+
             conn
             |> put_status(:created)
-            |> render("memberof.json", group: group)
+            |> render("memberof.json", group: group, user: conn.assigns[:current_user])
           {:error, :groups, changeset, %{}} ->
             conn
             |> put_status(:unprocessable_entity)
@@ -110,11 +111,9 @@ defmodule Thegm.GroupsController do
 
             meta = %{total: total, limit: settings.limit, offset: offset, count: length(groups)}
 
-            Enum.map(groups, fn g -> Groups.set_member_status(g, group_member_status(user_id, g)) end)
-
             conn
             |> put_status(:ok)
-            |> render("search.json", groups: groups, meta: meta)
+            |> render("search.json", groups: groups, meta: meta, user: conn.assigns[:current_user])
           true ->
             meta = %{total: total, limit: settings.limit, offset: offset, count: 0}
             conn
@@ -137,11 +136,9 @@ defmodule Thegm.GroupsController do
         |> put_status(:not_found)
         |> render(Thegm.ErrorView, "error.json", errors: ["A group with the specified `id` was not found"])
       group ->
-        group
-        |> Groups.set_member_status(group_member_status(user_id, group))
         conn
         |> put_status(:ok)
-        |> render("adminof.json", group: group)
+        |> render("adminof.json", group: group, user: conn.assigns[:current_user])
     end
   end
 
@@ -167,12 +164,10 @@ defmodule Thegm.GroupsController do
                 case Repo.update(group) do
                   {:ok, _} ->
                     group_response = Repo.one(groups_query(group_id, user_id))
-                    group_response
-                    |> Groups.set_member_status(group_member_status(user_id, group_response))
 
                     conn
                     |> put_status(:ok)
-                    |> render("adminof.json", group: group_response)
+                    |> render("adminof.json", group: group_response, user: conn.assigns[:current_user])
                   {:error, changeset} ->
                     conn
                     |> put_status(:unprocessable_entity)
@@ -279,19 +274,6 @@ defmodule Thegm.GroupsController do
     resp
   end
 
-  def get_member([], _) do
-    nil
-  end
-
-  def get_member([head | tail], user_id) do
-    cond do
-      head.users_id == user_id ->
-        head
-      true ->
-        get_member(tail, user_id)
-    end
-  end
-
   def get_admin([], _) do
     nil
   end
@@ -312,40 +294,5 @@ defmodule Thegm.GroupsController do
          left_join: gjr in GroupJoinRequests, on: gjr.group_id == g.id and gjr.user_id == ^user_id,
          where: (g.id == ^group_id),
          preload: [group_members: {gm, users: u}, join_requests: gjr]
-  end
-
-  def group_member_status(user_id, group) do
-    case get_member(group.group_members, user_id) do
-      nil ->
-        case group.join_requests do
-          # user has not previously requested to join the group
-          [] ->
-            false
-          # user has previously requested to join the group
-          join_requests ->
-            # Because we ordered by updated descending, get the most recent request
-            last = hd(join_requests)
-            cond do
-              # Last request is still open, error
-              last.status == nil ->
-                "pending"
-              # Last request was ignored, check how old it is
-              last.status == "ignored" ->
-                # Calculated how long it has been since they last requested
-                inserted_at = last.inserted_at |> DateTime.from_naive!("Etc/UTC")
-                diff = DateTime.diff(DateTime.utc_now, inserted_at, :second)
-                # if it has been less than 60 days since they last requested
-                if (diff / 60 / 60 / 24) < 60  do
-                  "pending"
-                else
-                  nil
-                end
-              true ->
-                nil
-            end
-        end
-      member ->
-        member.role
-    end
   end
 end

--- a/web/models/groups.ex
+++ b/web/models/groups.ex
@@ -30,7 +30,7 @@ defmodule Thegm.Groups do
 
   def set_member_status(model, status) do
     model
-    |> cast(%{member_status: status}, [:member_status])
+    |> put_change(:member_status, status)
   end
 
   def changeset(model, params \\ :empty) do

--- a/web/views/groups_view.ex
+++ b/web/views/groups_view.ex
@@ -1,39 +1,38 @@
 defmodule Thegm.GroupsView do
   use Thegm.Web, :view
 
-  def render("memberof.json", %{group: group}) do
+  def render("memberof.json", %{group: group, user: user}) do
     included = Enum.map(group.group_members, &user_hydration/1)
-    data = member_json(group)
+    data = member_json(group, user)
     %{
       data: data,
       included: included
     }
   end
 
-  def render("adminof.json", %{group: group}) do
+  def render("adminof.json", %{group: group, user: user}) do
     included = Enum.map(group.group_members, &user_hydration/1)
-    data = member_json(group)
+    data = member_json(group, user)
     %{
       data: data,
       included: included
     }
   end
 
-  def render("notmember.json", %{group: group}) do
-    data = non_member_json(group)
+  def render("notmember.json", %{group: group, user: user}) do
+    data = non_member_json(group, user)
     %{data: data}
   end
 
-  def render("pendingmember.json", %{group: group}) do
-    data = non_member_json(group)
-    %{data: data}
+  def render("search.json", %{groups: groups, meta: meta, user: user}) do
+    data = Enum.map(groups, fn g -> search_json(g, user) end)
+
+    %{meta: search_meta(meta), data: data}
   end
 
-  def render("search.json", %{groups: groups, meta: meta}) do
-    %{meta: search_meta(meta), data: Enum.map(groups, &search_json/1)}
-  end
+  def member_json(group, user) do
+    status = group_member_status(group, user)
 
-  def member_json(group) do
     %{
       type: "groups",
       id: group.id,
@@ -45,7 +44,7 @@ defmodule Thegm.GroupsView do
         games: group.games,
         members: length(group.group_members),
         slug: group.slug,
-        member_status: group.member_status
+        member_status: status
       },
       relationships: %{
         group_members: Thegm.GroupMembersView.groups_users(group.group_members)
@@ -53,7 +52,9 @@ defmodule Thegm.GroupsView do
     }
   end
 
-  def non_member_json(group) do
+  def non_member_json(group, user) do
+    status = group_member_status(group, user)
+
     %{
       type: "groups",
       id: group.id,
@@ -63,12 +64,14 @@ defmodule Thegm.GroupsView do
         games: group.games,
         members: length(group.group_members),
         slug: group.slug,
-        member_status: group.member_status
+        member_status: status
       }
     }
   end
 
-  def search_json(group) do
+  def search_json(group, user) do
+    status = group_member_status(group, user)
+
      %{
       type: "groups",
       id: group.id,
@@ -79,7 +82,7 @@ defmodule Thegm.GroupsView do
         members: length(group.group_members),
         slug: group.slug,
         distance: group.distance,
-        member_status: group.member_status
+        member_status: status
       }
     }
   end
@@ -112,5 +115,53 @@ defmodule Thegm.GroupsView do
       id: groupmember.groups_id,
       type: "groups"
     }
+  end
+
+  def group_member_status(group, user) do
+    case get_member(group.group_members, user.id) do
+      nil ->
+        case group.join_requests do
+          # user has not previously requested to join the group
+          [] ->
+            false
+          # user has previously requested to join the group
+          join_requests ->
+            # Because we ordered by updated descending, get the most recent request
+            last = hd(join_requests)
+            cond do
+              # Last request is still open, error
+              last.status == nil ->
+                "pending"
+              # Last request was ignored, check how old it is
+              last.status == "ignored" ->
+                # Calculated how long it has been since they last requested
+                inserted_at = last.inserted_at |> DateTime.from_naive!("Etc/UTC")
+                diff = DateTime.diff(DateTime.utc_now, inserted_at, :second)
+                # if it has been less than 60 days since they last requested
+                if (diff / 60 / 60 / 24) < 60  do
+                  "pending"
+                else
+                  nil
+                end
+              true ->
+                nil
+            end
+        end
+      member ->
+        member.role
+    end
+  end
+
+  def get_member([], _) do
+    nil
+  end
+
+  def get_member([head | tail], user_id) do
+    cond do
+      head.users_id == user_id ->
+        head
+      true ->
+        get_member(tail, user_id)
+    end
   end
 end


### PR DESCRIPTION
Group creation was failing due to the required field for slug being called before slug was cast to the model.

member_status now returns correct value. Virtual fields did not behave as expected and so member status generation has been moved to views.