### PR TITLE
[API-7] Fix Group Search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ erl_crash.dump
 /config/*.secret.exs
 
 # Profiles for exporting environment variables
+.local_env
 .dev_env
 .prod_env

--- a/priv/repo/migrations/20180307175324_alter_singular_to_plurals.exs
+++ b/priv/repo/migrations/20180307175324_alter_singular_to_plurals.exs
@@ -1,0 +1,15 @@
+defmodule Thegm.Repo.Migrations.AlterSingularToPlurals do
+  use Ecto.Migration
+
+  def change do
+    rename table(:group_join_requests), :user_id, to: :users_id
+    rename table(:group_join_requests), :group_id, to: :groups_id
+    rename table(:group_join_invites), :user_id, to: :users_id
+    rename table(:group_join_invites), :group_id, to: :groups_id
+    rename table(:group_blocked_users), :user_id, to: :users_id
+    rename table(:group_blocked_users), :group_id, to: :groups_id
+    rename table(:confirmation_codes), :user_id, to: :users_id
+    rename table(:sessions), :user_id, to: :users_id
+    rename table(:password_resets), :user_id, to: :users_id
+  end
+end

--- a/web/controllers/confirmationcodes_controller.ex
+++ b/web/controllers/confirmationcodes_controller.ex
@@ -4,8 +4,8 @@ defmodule Thegm.ConfirmationCodesController do
   alias Thegm.ConfirmationCodes
 
   # TODO: Once logging is implemented, add case for errors
-  def new(user_id, email) do
-    changeset = ConfirmationCodes.changeset(%ConfirmationCodes{},%{"used" => false, "user_id" => user_id})
+  def new(users_id, email) do
+    changeset = ConfirmationCodes.changeset(%ConfirmationCodes{},%{"used" => false, "users_id" => users_id})
     case Repo.insert(changeset) do
       {:ok, params} ->
         Thegm.Mailgun.email_confirmation_email(email, params.id)
@@ -29,7 +29,7 @@ defmodule Thegm.ConfirmationCodesController do
           code = ConfirmationCodes.changeset(resp, %{used: true})
           case Repo.update(code) do
             {:ok, resp2} ->
-              case Repo.get(Thegm.Users, resp2.user_id) do
+              case Repo.get(Thegm.Users, resp2.users_id) do
                 nil ->
                   conn
                   |> put_status(:not_found)
@@ -38,7 +38,7 @@ defmodule Thegm.ConfirmationCodesController do
                   user = Thegm.Users.changeset(resp3, %{active: true})
                   case Repo.update(user) do
                     {:ok, resp4} ->
-                      session_changeset = Thegm.Sessions.create_changeset(%Thegm.Sessions{}, %{user_id: resp4.id})
+                      session_changeset = Thegm.Sessions.create_changeset(%Thegm.Sessions{}, %{users_id: resp4.id})
                       case Repo.insert(session_changeset) do
                         {:ok, session} ->
                           conn

--- a/web/controllers/groups_controller.ex
+++ b/web/controllers/groups_controller.ex
@@ -43,15 +43,15 @@ defmodule Thegm.GroupsController do
     end
   end
 
-  def delete(conn, %{"id" => group_id}) do
-    user_id = conn.assigns[:current_user].id
-    case Repo.get(Groups, group_id) |> Repo.preload(:group_members) do
+  def delete(conn, %{"id" => groups_id}) do
+    users_id = conn.assigns[:current_user].id
+    case Repo.get(Groups, groups_id) |> Repo.preload(:group_members) do
       nil ->
         conn
         |> put_status(:not_found)
         |> render(Thegm.ErrorView, "error.json", errors: ["Group not found, maybe you already deleted it?"])
       group ->
-        case Enum.find(group.group_members, fn x -> x.users_id == user_id end) do
+        case Enum.find(group.group_members, fn x -> x.users_id == users_id end) do
           nil ->
             conn
             |> put_status(:forbidden)
@@ -77,13 +77,12 @@ defmodule Thegm.GroupsController do
   end
 
   def index(conn, params) do
-    user_id = conn.assigns[:current_user].id
+    users_id = conn.assigns[:current_user].id
     case read_search_params(params) do
       {:ok, settings} ->
-        user_id = conn.assigns[:current_user].id
         # Get user's current groups so we can properly exclude them
-        memberships = Repo.all(from m in Thegm.GroupMembers, where: m.users_id == ^user_id, select: m.groups_id)
-        blocks = Repo.all(from b in Thegm.GroupBlockedUsers, where: b.user_id == ^user_id and b.rescinded == false, select: b.group_id)
+        memberships = Repo.all(from m in Thegm.GroupMembers, where: m.users_id == ^users_id, select: m.groups_id)
+        blocks = Repo.all(from b in Thegm.GroupBlockedUsers, where: b.users_id == ^users_id and b.rescinded == false, select: b.groups_id)
         # Group search params
         offset = (settings.page - 1) * settings.limit
         geom = %Geo.Point{coordinates: {settings.lng, settings.lat}, srid: 4326}
@@ -102,7 +101,7 @@ defmodule Thegm.GroupsController do
               where: st_distancesphere(g.geom, ^geom) <= ^settings.meters and not g.id in ^memberships and not g.id in ^blocks and g.discoverable == true,
               left_join: gm in assoc(g, :group_members),
               left_join: u in assoc(gm, :users),
-              left_join: gjr in GroupJoinRequests, on: gjr.group_id == g.id and gjr.user_id == ^user_id,
+              left_join: gjr in GroupJoinRequests, on: gjr.groups_id == g.id and gjr.users_id == ^users_id,
               preload: [group_members: {gm, users: u}, join_requests: gjr],
               order_by: [asc: st_distancesphere(g.geom, ^geom)],
               limit: ^settings.limit,
@@ -127,10 +126,10 @@ defmodule Thegm.GroupsController do
     end
   end
 
-  def show(conn, %{"id" => group_id}) do
-    user_id = conn.assigns[:current_user].id
+  def show(conn, %{"id" => groups_id}) do
+    users_id = conn.assigns[:current_user].id
 
-    case Repo.one(groups_query(group_id, user_id)) do
+    case Repo.one(groups_query(groups_id, users_id)) do
       nil ->
         conn
         |> put_status(:not_found)
@@ -142,11 +141,11 @@ defmodule Thegm.GroupsController do
     end
   end
 
-  def update(conn, %{"id" => group_id, "data" => %{"attributes" => params, "type" => type}}) do
-    user_id = conn.assigns[:current_user].id
+  def update(conn, %{"id" => groups_id, "data" => %{"attributes" => params, "type" => type}}) do
+    users_id = conn.assigns[:current_user].id
     cond do
       type == "groups" ->
-        case Repo.one(from m in Thegm.GroupMembers, where: m.groups_id == ^group_id and m.users_id == ^user_id) |> Repo.preload(:groups) do
+        case Repo.one(from m in Thegm.GroupMembers, where: m.groups_id == ^groups_id and m.users_id == ^users_id) |> Repo.preload(:groups) do
           nil ->
             conn
             |> put_status(:forbidden)
@@ -163,7 +162,7 @@ defmodule Thegm.GroupsController do
                 end
                 case Repo.update(group) do
                   {:ok, _} ->
-                    group_response = Repo.one(groups_query(group_id, user_id))
+                    group_response = Repo.one(groups_query(groups_id, users_id))
 
                     conn
                     |> put_status(:ok)
@@ -278,21 +277,21 @@ defmodule Thegm.GroupsController do
     nil
   end
 
-  def get_admin([head | tail], user_id) do
+  def get_admin([head | tail], users_id) do
     cond do
-      head.users_id == user_id and head.role == "admin" ->
+      head.users_id == users_id and head.role == "admin" ->
         head
       true ->
-        get_admin(tail, user_id)
+        get_admin(tail, users_id)
     end
   end
 
-  def groups_query(group_id, user_id) do
+  def groups_query(groups_id, users_id) do
     from g in Groups,
          left_join: gm in assoc(g, :group_members),
          left_join: u in assoc(gm, :users),
-         left_join: gjr in GroupJoinRequests, on: gjr.group_id == g.id and gjr.user_id == ^user_id,
-         where: (g.id == ^group_id),
+         left_join: gjr in GroupJoinRequests, on: gjr.groups_id == g.id and gjr.users_id == ^users_id,
+         where: (g.id == ^groups_id),
          preload: [group_members: {gm, users: u}, join_requests: gjr]
   end
 end

--- a/web/controllers/passwordresets_controller.ex
+++ b/web/controllers/passwordresets_controller.ex
@@ -11,8 +11,8 @@ defmodule Thegm.PasswordResetsController do
 
         cond do
           user ->
-            Repo.delete_all(PasswordResets, [user_id: user.id, used: false])
-            changeset = PasswordResets.changeset(%PasswordResets{},%{"used" => false, "user_id" => user.id})
+            Repo.delete_all(PasswordResets, [usesr_id: user.id, used: false])
+            changeset = PasswordResets.changeset(%PasswordResets{},%{"used" => false, "users_id" => user.id})
 
             case Repo.insert(changeset) do
               {:ok, reset} ->
@@ -45,7 +45,7 @@ defmodule Thegm.PasswordResetsController do
             code = PasswordResets.changeset(resp, %{used: true})
             case Repo.update(code) do
               {:ok, updated_code} ->
-                case Repo.get(Thegm.Users, updated_code.user_id) do
+                case Repo.get(Thegm.Users, updated_code.users_id) do
                   nil ->
                     conn
                     |> put_status(:not_found)

--- a/web/controllers/sessions_controller.ex
+++ b/web/controllers/sessions_controller.ex
@@ -36,7 +36,7 @@ defmodule Thegm.SessionsController do
             |> put_status(:bad_request)
             |> render(Thegm.ErrorView, "error.json", errors: ["Account has not been verified"])
           user && checkpw(user_params["password"], user.password_hash) ->
-            session_changeset = Sessions.create_changeset(%Sessions{}, %{user_id: user.id})
+            session_changeset = Sessions.create_changeset(%Sessions{}, %{users_id: user.id})
             {:ok, session} = Repo.insert(session_changeset)
             conn
             |> put_status(:created)

--- a/web/controllers/useravatars_controller.ex
+++ b/web/controllers/useravatars_controller.ex
@@ -7,17 +7,17 @@ defmodule Thegm.UserAvatarsController do
 
   import Mogrify
 
-  def create(conn, %{"users_id" => user_id, "file" => image_params}) do
+  def create(conn, %{"users_id" => users_id, "file" => image_params}) do
     current_user_id = conn.assigns[:current_user].id
 
-    case Repo.get(Users, user_id) do
+    case Repo.get(Users, users_id) do
       nil ->
         conn
         |> put_status(:not_found)
         |> render(Thegm.ErrorView, "error.json", errors: ["A user with the specified `id` was not found"])
       user ->
         cond do
-          current_user_id == user_id ->
+          current_user_id == users_id ->
             open(image_params.path)
             |> resize("512x512")
             |> format("jpg")
@@ -42,8 +42,8 @@ defmodule Thegm.UserAvatarsController do
     end
   end
 
-  def show(conn, %{"id" => user_id}) do
-    case Repo.get(Users, user_id) do
+  def show(conn, %{"id" => users_id}) do
+    case Repo.get(Users, users_id) do
       nil ->
         conn
         |> put_status(:not_found)
@@ -64,17 +64,17 @@ defmodule Thegm.UserAvatarsController do
     end
   end
 
-  def delete(conn, %{"users_id" => user_id}) do
+  def delete(conn, %{"users_id" => users_id}) do
     current_user_id = conn.assigns[:current_user].id
 
-    case Repo.get(Users, user_id) do
+    case Repo.get(Users, users_id) do
       nil ->
         conn
         |> put_status(:not_found)
         |> render(Thegm.ErrorView, "error.json", errors: ["A user with the specified `id` was not found"])
       user ->
         cond do
-          current_user_id == user_id ->
+          current_user_id == users_id ->
             avatar_identifier = generate_uuid(user.username)
             AWS.remove_avatar(avatar_identifier)
 

--- a/web/controllers/useremails_controller.ex
+++ b/web/controllers/useremails_controller.ex
@@ -6,17 +6,17 @@ defmodule Thegm.UserEmailsController do
   import Comeonin.Argon2, only: [checkpw: 2, dummy_checkpw: 0]
 
 
-  def update(conn, %{"users_id" => user_id, "data" => %{"attributes" => params, "type" => type}}) do
+  def update(conn, %{"users_id" => users_id, "data" => %{"attributes" => params, "type" => type}}) do
     current_user_id = conn.assigns[:current_user].id
 
-    case Repo.get(Users, user_id) |> Repo.preload([{:group_members, :groups}]) do
+    case Repo.get(Users, users_id) |> Repo.preload([{:group_members, :groups}]) do
       nil ->
         conn
         |> put_status(:not_found)
         |> render(Thegm.ErrorView, "error.json", errors: ["A user with the specified `username` was not found"])
       user ->
         cond do
-          current_user_id == user_id  ->
+          current_user_id == users_id  ->
             user = Users.update_email(user, params)
             case Repo.update(user) do
               {:ok, result} ->

--- a/web/controllers/userjoinrequests_controller.ex
+++ b/web/controllers/userjoinrequests_controller.ex
@@ -3,11 +3,11 @@ defmodule Thegm.UserJoinRequestsController do
 
   alias Thegm.UserJoinRequests
 
-  def index(conn, %{"user_id" => user_id}) do
-    
+  def index(conn, %{"users_id" => users_id}) do
+
   end
 
-  def delete(conn, %{"user_id" => user_id, "request_id" => request_id}) do
+  def delete(conn, %{"users_id" => users_id, "requests_id" => requests_id}) do
 
   end
 end

--- a/web/controllers/userpasswords_controller.ex
+++ b/web/controllers/userpasswords_controller.ex
@@ -6,17 +6,17 @@ defmodule Thegm.UserPasswordsController do
   import Comeonin.Argon2, only: [checkpw: 2, dummy_checkpw: 0]
 
 
-  def update(conn, %{"users_id" => user_id, "data" => %{"attributes" => params, "type" => type}}) do
+  def update(conn, %{"users_id" => users_id, "data" => %{"attributes" => params, "type" => type}}) do
     current_user_id = conn.assigns[:current_user].id
 
-    case Repo.get(Users, user_id) |> Repo.preload([{:group_members, :groups}]) do
+    case Repo.get(Users, users_id) |> Repo.preload([{:group_members, :groups}]) do
       nil ->
         conn
         |> put_status(:not_found)
         |> render(Thegm.ErrorView, "error.json", errors: ["A user with the specified `username` was not found"])
       user ->
         cond do
-          current_user_id == user_id && checkpw(params["current_password"], user.password_hash) ->
+          current_user_id == users_id && checkpw(params["current_password"], user.password_hash) ->
             user = Users.update_password(user, params)
             case Repo.update(user) do
               {:ok, result} ->

--- a/web/controllers/users_controller.ex
+++ b/web/controllers/users_controller.ex
@@ -31,19 +31,19 @@ defmodule Thegm.UsersController do
     end
   end
 
-  def update(conn, %{"id" => user_id, "data" => %{"attributes" => params, "type" => type}}) do
+  def update(conn, %{"id" => users_id, "data" => %{"attributes" => params, "type" => type}}) do
     current_user_id = conn.assigns[:current_user].id
 
     cond do
       type == "users" ->
-        case Repo.get(Users, user_id) |> Repo.preload([{:group_members, :groups}]) do
+        case Repo.get(Users, users_id) |> Repo.preload([{:group_members, :groups}]) do
           nil ->
             conn
             |> put_status(:not_found)
             |> render(Thegm.ErrorView, "error.json", errors: ["A user with the specified `username` was not found"])
           user ->
             cond do
-              current_user_id == user_id ->
+              current_user_id == users_id ->
                 user = Users.unrestricted_changeset(user, params)
                 case Repo.update(user) do
                   {:ok, result} ->
@@ -68,17 +68,17 @@ defmodule Thegm.UsersController do
     end
   end
 
-  def show(conn, %{"id" => user_id}) do
+  def show(conn, %{"id" => users_id}) do
     current_user_id = conn.assigns[:current_user].id
 
-    case Repo.get(Users, user_id) |> Repo.preload([{:group_members, :groups}]) do
+    case Repo.get(Users, users_id) |> Repo.preload([{:group_members, :groups}]) do
       nil ->
         conn
         |> put_status(:not_found)
         |> render(Thegm.ErrorView, "error.json", errors: ["A user with the specified `username` was not found"])
       user ->
       cond do
-        current_user_id == user_id ->
+        current_user_id == users_id ->
           render conn, "private.json", user: user
         true ->
           render conn, "public.json", user: user

--- a/web/models/confirmationcodes.ex
+++ b/web/models/confirmationcodes.ex
@@ -7,17 +7,17 @@ defmodule Thegm.ConfirmationCodes do
 
   schema "confirmation_codes" do
     field :used, :boolean
-    belongs_to :user, Thegm.Users
+    belongs_to :users, Thegm.Users
 
     timestamps()
   end
 
   @doc """
-  Builds a changeset based on the `struct` and `user_id`.
+  Builds a changeset based on the `struct` and `users_id`.
   """
 
   def changeset(model, params \\ :empty) do
     model
-    |> cast(params, [:used, :user_id])
+    |> cast(params, [:used, :users_id])
   end
 end

--- a/web/models/groupblockedusers.ex
+++ b/web/models/groupblockedusers.ex
@@ -7,7 +7,7 @@ defmodule Thegm.GroupBlockedUsers do
 
   schema "group_blocked_users" do
     field :rescinded, :boolean
-    belongs_to :user, Thegm.Users
-    belongs_to :group, Thegm.Groups
+    belongs_to :users, Thegm.Users
+    belongs_to :groups, Thegm.Groups
   end
 end

--- a/web/models/groupjoinrequests.ex
+++ b/web/models/groupjoinrequests.ex
@@ -8,17 +8,17 @@ defmodule Thegm.GroupJoinRequests do
   schema "group_join_requests" do
     field :status, :string
     field :pending, :boolean
-    belongs_to :user, Thegm.Users
-    belongs_to :group, Thegm.Groups
+    belongs_to :users, Thegm.Users
+    belongs_to :groups, Thegm.Groups
 
     timestamps()
   end
 
   def create_changeset(model, params \\ :empty) do
     model
-    |> cast(params, [:status, :group_id, :user_id])
-    |> validate_required([:user_id, :group_id])
-    |> unique_constraint(:user_id, name: :group_join_requests_user_id_group_id_pending_index)
+    |> cast(params, [:status, :groups_id, :users_id])
+    |> validate_required([:users_id, :groups_id])
+    |> unique_constraint(:users_id, name: :group_join_requests_user_id_group_id_pending_index)
   end
 
   def update_changeset(model, params \\ :empty) do

--- a/web/models/passwordresets.ex
+++ b/web/models/passwordresets.ex
@@ -7,17 +7,17 @@ defmodule Thegm.PasswordResets do
 
   schema "password_resets" do
     field :used, :boolean
-    belongs_to :user, Thegm.Users
+    belongs_to :users, Thegm.Users
 
     timestamps()
   end
 
   @doc """
-  Builds a changeset based on the `struct` and `user_id`.
+  Builds a changeset based on the `struct` and `users_id`.
   """
 
   def changeset(model, params \\ :empty) do
     model
-    |> cast(params, [:used, :user_id])
+    |> cast(params, [:used, :users_id])
   end
 end

--- a/web/models/sessions.ex
+++ b/web/models/sessions.ex
@@ -4,7 +4,7 @@ defmodule Thegm.Sessions do
   @foreign_key_type :binary_id
   schema "sessions" do
     field :token, :string
-    belongs_to :user, Thegm.Users
+    belongs_to :users, Thegm.Users
 
     timestamps()
   end
@@ -14,8 +14,8 @@ defmodule Thegm.Sessions do
   """
   def changeset(model, params \\ :empty) do
     model
-    |> cast(params, [:token, :user_id])
-    |> validate_required([:user_id])
+    |> cast(params, [:token, :users_id])
+    |> validate_required([:users_id])
   end
 
   def create_changeset(model, params \\ :empty) do

--- a/web/plugs/authenticate_user.ex
+++ b/web/plugs/authenticate_user.ex
@@ -33,7 +33,7 @@ defmodule Thegm.AuthenticateUser do
   end
 
   defp find_user_by_session(session) do
-    case Repo.get(Users, session.user_id) do
+    case Repo.get(Users, session.users_id) do
       nil -> :error
       user -> {:ok, user}
     end

--- a/web/views/groupjoinrequests_view.ex
+++ b/web/views/groupjoinrequests_view.ex
@@ -11,7 +11,7 @@ defmodule Thegm.GroupJoinRequestsView do
   def hydrate_pending_user(request) do
     join_request = %{
       type: "join-requests",
-      id: request.user_id,
+      id: request.users_id,
       attributes: Thegm.UsersView.users_private(request.user)
     }
     join_request = put_in(join_request, [:attributes, :status], "pending")

--- a/web/views/groups_view.ex
+++ b/web/views/groups_view.ex
@@ -156,12 +156,12 @@ defmodule Thegm.GroupsView do
     nil
   end
 
-  def get_member([head | tail], user_id) do
+  def get_member([head | tail], users_id) do
     cond do
-      head.users_id == user_id ->
+      head.users_id == users_id ->
         head
       true ->
-        get_member(tail, user_id)
+        get_member(tail, users_id)
     end
   end
 end

--- a/web/views/groups_view.ex
+++ b/web/views/groups_view.ex
@@ -44,7 +44,8 @@ defmodule Thegm.GroupsView do
         games: group.games,
         members: length(group.group_members),
         slug: group.slug,
-        member_status: status
+        member_status: status,
+        discoverable: group.discoverable
       },
       relationships: %{
         group_members: Thegm.GroupMembersView.groups_users(group.group_members)
@@ -64,7 +65,8 @@ defmodule Thegm.GroupsView do
         games: group.games,
         members: length(group.group_members),
         slug: group.slug,
-        member_status: status
+        member_status: status,
+        discoverable: group.discoverable
       }
     }
   end

--- a/web/views/sessions_view.ex
+++ b/web/views/sessions_view.ex
@@ -6,6 +6,6 @@ defmodule Thegm.SessionsView do
   end
 
   def session_json(session) do
-    %{type: "sessions", attributes: %{token: session.token, user_id: session.user_id}}
+    %{type: "sessions", attributes: %{token: session.token, user_id: session.users_id}}
   end
 end


### PR DESCRIPTION
I had to refactor references of `user_id` and `group_id` to `users_id` and `groups_id` (imagine them as possessive). This allows us to remove the SQL `join` statements in the group search and instead just have `preload` ecto statements.