### PR TITLE
[API-20] Check that email address is unique

### DIFF
--- a/web/controllers/unique_controller.ex
+++ b/web/controllers/unique_controller.ex
@@ -1,0 +1,19 @@
+defmodule Thegm.UniqueController do
+  use Thegm.Web, :controller
+
+  def show(conn, %{"email" => email}) do
+    cond do
+      Regex.match?(~r/@/, email) ->
+        case Repo.one(from u in Thegm.Users, where: u.email == ^email) do
+          nil ->
+            send_resp(conn, :no_content, "")
+          _ ->
+            send_resp(conn, :conflict, "")
+        end
+      true ->
+        conn
+        |> put_status(:bad_request)
+        |>render(Thegm.ErrorView, "error.json", errors: ["email: must be valid email address"])
+    end
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -47,6 +47,7 @@ defmodule Thegm.Router do
     get "/sessions/:id", SessionsController, :show
     post "/confirmation/:id", ConfirmationCodesController, :create
     get "/users/:id/avatar", UserAvatarsController, :show
+    get "/unique", UniqueController, :show
 
     post "/resets", PasswordResetsController, :create
     put "/resets/:id", PasswordResetsController, :update


### PR DESCRIPTION
It does that.
`{{api-protocol}}://{{api-host}}/unique/?email={{email}}`
Responds 204 if the email address is not registered
Responds 409 if the email address is registered