### PR TITLE
API-44/games-list fixes

### DIFF
--- a/priv/repo/migrations/20180327203921_remove_groups_gamesarray.exs
+++ b/priv/repo/migrations/20180327203921_remove_groups_gamesarray.exs
@@ -1,0 +1,9 @@
+defmodule Thegm.Repo.Migrations.RemoveGroupsGamesarray do
+  use Ecto.Migration
+
+  def change do
+    alter table("groups") do
+      remove :games
+    end
+  end
+end

--- a/web/controllers/games_controller.ex
+++ b/web/controllers/games_controller.ex
@@ -19,7 +19,7 @@ defmodule Thegm.GamesController do
           total > 0 ->
             games = Repo.all(
                         from g in Games,
-                        left_outer_join: gd in GameDisambiguations, where: gd.games_id == g.id,
+                        left_join: gd in GameDisambiguations, where: gd.games_id == g.id,
                         where: ilike(g.name, ^query) or ilike(gd.name, ^query),
                         limit: ^settings.limit,
                         offset: ^offset

--- a/web/controllers/games_controller.ex
+++ b/web/controllers/games_controller.ex
@@ -19,7 +19,7 @@ defmodule Thegm.GamesController do
           total > 0 ->
             games = Repo.all(
                         from g in Games,
-                        join: gd in GameDisambiguations, where: gd.games_id == g.id,
+                        left_outer_join: gd in GameDisambiguations, where: gd.games_id == g.id,
                         where: ilike(g.name, ^query) or ilike(gd.name, ^query),
                         limit: ^settings.limit,
                         offset: ^offset

--- a/web/models/groups.ex
+++ b/web/models/groups.ex
@@ -11,7 +11,6 @@ defmodule Thegm.Groups do
     field :slug, :string, null: false
     field :description, :string
     field :address, :string, null: true
-    field :games, {:array, :string}
     field :distance, :float, virtual: true
     field :geom, Geo.Geometry
     field :discoverable, :boolean

--- a/web/views/games_view.ex
+++ b/web/views/games_view.ex
@@ -13,10 +13,10 @@ defmodule Thegm.GamesView do
   end
 
   #show multiple users
-  def render("index.json", %{games: games}) do
-    %{
-      games: Enum.map(games, &games_show/1)
-    }
+  def render("index.json", %{games: games, meta: meta}) do
+    data = Enum.map(games, &games_show/1)
+
+    %{meta: search_meta(meta), data: data}
   end
 
   def games_show(game) do
@@ -35,6 +35,10 @@ defmodule Thegm.GamesView do
       id: game.id,
       type: "games"
     }
+  end
+
+  def search_meta(meta) do
+    %{total: meta.total, count: meta.count, limit: meta.limit, offset: meta.offset}
   end
 
   def users_usergames_games(game) do

--- a/web/views/groups_view.ex
+++ b/web/views/groups_view.ex
@@ -43,7 +43,6 @@ defmodule Thegm.GroupsView do
         description: group.description,
         address: group.address,
         geo: Thegm.GeoView.geo(group.geom),
-        games: group.games,
         members: length(group.group_members),
         slug: group.slug,
         member_status: status,
@@ -63,7 +62,6 @@ defmodule Thegm.GroupsView do
       attributes: %{
         name: group.name,
         description: group.description,
-        games: group.games,
         members: length(group.group_members),
         slug: group.slug,
         member_status: status,
@@ -82,7 +80,6 @@ defmodule Thegm.GroupsView do
       attributes: %{
         name: group.name,
         description: group.description,
-        games: group.games,
         slug: group.slug,
         discoverable: group.discoverable
       },

--- a/web/views/groups_view.ex
+++ b/web/views/groups_view.ex
@@ -82,9 +82,6 @@ defmodule Thegm.GroupsView do
         description: group.description,
         slug: group.slug,
         discoverable: group.discoverable
-      },
-      relationships: %{
-        group_games: Thegm.GroupGamesView.groups_games(group.group_games)
       }
     }
   end


### PR DESCRIPTION
This PR addresses a number of issues discovered during QA:
* Views should no longer attempt to return the old games list array in groups   
* Nested relationships should no longer attempt to load games data.
* Games search will no longer only return results that have a disambiguation associated with them.