### PR TITLE
API-44/Games List™:  The confusing remake with the same name as the original

### DIFF
--- a/web/controllers/games_controller.ex
+++ b/web/controllers/games_controller.ex
@@ -37,7 +37,7 @@ defmodule Thegm.GamesController do
             meta = %{total: total, limit: settings.limit, offset: offset, count: 0}
             conn
             |> put_status(:ok)
-            |> render("index.json", threads: [], meta: meta)
+            |> render("index.json", games: [], meta: meta)
         end
       {:error, errors} ->
         conn


### PR DESCRIPTION
Fixes an issue discovered in QA where games search would break when no results are found