### PR TITLE
API-48/admin-group-members - Add the ability for the group owner to promote admins in the group

### DIFF
--- a/priv/repo/migrations/20180330143450_change_existing_admins_to_owner.exs
+++ b/priv/repo/migrations/20180330143450_change_existing_admins_to_owner.exs
@@ -1,0 +1,7 @@
+defmodule Thegm.Repo.Migrations.ChangeExistingAdminsToOwner do
+  use Ecto.Migration
+
+  def change do
+    execute "UPDATE group_members SET \"role\" = 'owner' WHERE \"role\" = 'admin'"
+  end
+end

--- a/web/controllers/groupevents_controller.ex
+++ b/web/controllers/groupevents_controller.ex
@@ -2,6 +2,7 @@ defmodule Thegm.GroupEventsController do
   use Thegm.Web, :controller
 
   alias Thegm.GroupEvents
+  alias Thegm.GroupMembers
 
   def create(conn, %{"groups_id" => groups_id, "data" => %{"attributes" => params, "type" => type}}) do
     users_id = conn.assigns[:current_user].id
@@ -12,7 +13,7 @@ defmodule Thegm.GroupEventsController do
         |> render(Thegm.ErrorView, "error.json", errors: ["Must be a member of the group"])
       member ->
         cond do
-          member.role == "admin" ->
+          GroupMembers.isAdmin(member) ->
             case {type, params} do
               {"events", params} ->
                 case read_start_end(params) do

--- a/web/controllers/groupgames_controller.ex
+++ b/web/controllers/groupgames_controller.ex
@@ -4,6 +4,7 @@ defmodule Thegm.GroupGamesController do
   alias Thegm.GroupGames
   alias Thegm.Groups
   alias Ecto.Multi
+  alias Thegm.GroupMembers
 
   def index(conn, params) do
     case read_params(params) do
@@ -58,7 +59,7 @@ defmodule Thegm.GroupGamesController do
             |> put_status(:not_found)
             |> render(Thegm.ErrorView, "error.json", errors: ["members: You are not a member of the group"])
 
-          current_user_member.role != "admin" ->
+          GroupMembers.isAdmin(current_user_member) == false ->
             conn
             |> put_status(:forbidden)
             |> render(Thegm.ErrorView, "error.json", errors: ["You do not have permission to add games"])
@@ -111,7 +112,7 @@ defmodule Thegm.GroupGamesController do
             |> put_status(:not_found)
             |> render(Thegm.ErrorView, "error.json", errors: ["members: You are not a member of the group"])
 
-          current_user_member.role != "admin" ->
+          GroupMembers.isAdmin(current_user_member) == false ->
             conn
             |> put_status(:forbidden)
             |> render(Thegm.ErrorView, "error.json", errors: ["You do not have permission to modify games"])
@@ -170,7 +171,7 @@ defmodule Thegm.GroupGamesController do
             |> put_status(:not_found)
             |> render(Thegm.ErrorView, "error.json", errors: ["members: You are not a member of the group"])
 
-          current_user_member.role != "admin" ->
+          GroupMembers.isAdmin(current_user_member) == false ->
             conn
             |> put_status(:forbidden)
             |> render(Thegm.ErrorView, "error.json", errors: ["You do not have permission to remove this game"])

--- a/web/models/groupmembers.ex
+++ b/web/models/groupmembers.ex
@@ -5,6 +5,9 @@ defmodule Thegm.GroupMembers do
   @derive {Phoenix.Param, key: :id}
   @foreign_key_type :binary_id
 
+  @member_roles ["owner", "admin", "member"]
+  @admin_roles ["owner", "admin"]
+
   schema "group_members" do
     field :role, :string
     field :active, :boolean
@@ -25,10 +28,24 @@ defmodule Thegm.GroupMembers do
   def role_changeset(model, params \\ :empty) do
     model
     |> cast(params, [:role])
+    |> validate_required([:role], message: "Are required")
+    |> validate_inclusion(:role, @member_roles)
   end
 
   def tombstone_changeset(model) do
     model
     |> put_change(:active, nil)
+  end
+
+  def isOwner(model) do
+    model.role == "owner"
+  end
+
+  def isAdmin(model) do
+    Enum.any?(@admin_roles, fn role -> model.role == role end)
+  end
+
+  def isMember(model) do
+    Enum.any?(@member_roles, fn role -> model.role == role end)
   end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -29,7 +29,7 @@ defmodule Thegm.Router do
 
     resources "/groups", GroupsController, only: [:create, :update, :delete] do
       resources "/events", GroupEventsController, only: [:create]
-      resources "/members", GroupMembersController, only: [:index, :delete]
+      resources "/members", GroupMembersController, only: [:index, :delete, :update]
       resources "/join-requests", GroupJoinRequestsController, only: [:create, :update, :index]
       resources "/threads", GroupThreadsController, only: [:create, :index, :show, :delete] do
         resources "/comments", GroupThreadCommentsController, only: [:create, :index, :show, :delete]

--- a/web/views/groups_view.ex
+++ b/web/views/groups_view.ex
@@ -1,12 +1,12 @@
 defmodule Thegm.GroupsView do
   use Thegm.Web, :view
-
+  alias Thegm.GroupMembers
 
   def render("show.json", %{group: group, users_id: users_id}) do
     data = show_json(group, users_id)
-    status = data[:attributes][:member_status]
+    member = data[:attributes][:member_status]
     cond do
-       status == "member" or status == "admin" ->
+       GroupMembers.isMember(%{role: member}) ->
         included = Enum.map(group.group_members, &user_hydration/1) ++ Enum.map(group.group_games, &game_hydration/1)
         %{
           data: data,
@@ -27,7 +27,7 @@ defmodule Thegm.GroupsView do
   def show_json(group, user) do
     status = group_member_status(group, user)
     cond do
-      status == "member" or status == "admin" ->
+      GroupMembers.isMember(%{role: status}) ->
        member_json(group, status)
       true ->
         non_member_json(group, status)


### PR DESCRIPTION
⚠️ Needs front-end update to support changes to the role parameter before API can be deployed ⚠️ 
