### PR TITLE
API-64 Fix missing ID in session results

### DIFF
--- a/priv/repo/migrations/20180402180056_sessions_uuid_primary_key.exs
+++ b/priv/repo/migrations/20180402180056_sessions_uuid_primary_key.exs
@@ -2,11 +2,9 @@ defmodule Thegm.Repo.Migrations.SessionsUuidPrimaryKey do
   use Ecto.Migration
 
   def change do
-    execute "TRUNCATE sessions"
-
     alter table(:sessions) do
       remove :id
-      add :id, :uuid, primary_key: true
+      modify :token, :string, primary_key: true
     end
   end
 end

--- a/priv/repo/migrations/20180402180056_sessions_uuid_primary_key.exs
+++ b/priv/repo/migrations/20180402180056_sessions_uuid_primary_key.exs
@@ -1,0 +1,12 @@
+defmodule Thegm.Repo.Migrations.SessionsUuidPrimaryKey do
+  use Ecto.Migration
+
+  def change do
+    execute "TRUNCATE sessions"
+
+    alter table(:sessions) do
+      remove :id
+      add :id, :uuid, primary_key: true
+    end
+  end
+end

--- a/web/models/sessions.ex
+++ b/web/models/sessions.ex
@@ -1,11 +1,10 @@
 defmodule Thegm.Sessions do
   use Thegm.Web, :model
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @derive {Phoenix.Param, key: :id}
+  @primary_key {:token, :string, autogenerate: false}
+  @derive {Phoenix.Param, key: :token}
   @foreign_key_type :binary_id
   schema "sessions" do
-    field :token, :string
     belongs_to :users, Thegm.Users
 
     timestamps()

--- a/web/models/sessions.ex
+++ b/web/models/sessions.ex
@@ -1,6 +1,8 @@
 defmodule Thegm.Sessions do
   use Thegm.Web, :model
 
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @derive {Phoenix.Param, key: :id}
   @foreign_key_type :binary_id
   schema "sessions" do
     field :token, :string

--- a/web/views/sessions_view.ex
+++ b/web/views/sessions_view.ex
@@ -7,7 +7,7 @@ defmodule Thegm.SessionsView do
 
   def session_json(session) do
     %{
-      id: session.id,
+      id: session.token,
       type: "sessions",
       attributes: %{
         token: session.token,

--- a/web/views/sessions_view.ex
+++ b/web/views/sessions_view.ex
@@ -6,6 +6,13 @@ defmodule Thegm.SessionsView do
   end
 
   def session_json(session) do
-    %{type: "sessions", attributes: %{token: session.token, user_id: session.users_id}}
+    %{
+      id: session.id,
+      type: "sessions",
+      attributes: %{
+        token: session.token,
+        user_id: session.users_id
+      }
+    }
   end
 end


### PR DESCRIPTION
Provide the session ID on successful login and in GET /sessions results. This is so clients can easily verify whether their current session is still valid.