### PR TITLE
API-63/group members inconsistency

### DIFF
--- a/web/views/groupmembers_view.ex
+++ b/web/views/groupmembers_view.ex
@@ -11,8 +11,8 @@ defmodule Thegm.GroupMembersView do
       type: "members",
       id: member.id,
       attributes: %{
-        user_id: member.users_id,
-        group_id: member.groups_id,
+        users_id: member.users_id,
+        groups_id: member.groups_id,
         role: member.role
       },
       relationships: %{

--- a/web/views/groupmembers_view.ex
+++ b/web/views/groupmembers_view.ex
@@ -1,34 +1,23 @@
 defmodule Thegm.GroupMembersView do
   use Thegm.Web, :view
 
-  def render("members.json", %{members: members}) do
-    %{data: Enum.map(members, &member/1)}
-  end
-
-  def member(member) do
-    base = Application.get_env(:thegm, :api_url)
+  def render("index.json", %{members: members, meta: meta}) do
     %{
-      type: "members",
-      id: member.id,
-      attributes: %{
-        users_id: member.users_id,
-        groups_id: member.groups_id,
-        role: member.role
-      },
-      relationships: %{
-        group: %{
-          links: %{
-            self: base <> "/groups/" <> member.groups_id
-          }
-        },
-        user: %{
-          links: %{
-            self: base <> "/users/" <> member.users_id
-          }
-        }
-      }
+      meta: Thegm.MetaView.meta(meta),
+      data: Enum.map(members, &hydrate_group_member/1)
     }
   end
+
+  def hydrate_group_member(member) do
+    groupmember_hydration = %{
+      type: "group-members",
+      id: member.users_id,
+      attributes: Thegm.UsersView.users_private(member.users)
+    }
+    groupmember_hydration = put_in(groupmember_hydration, [:attributes, :role], member.role)
+    put_in(groupmember_hydration, [:attributes, :inserted_at], member.inserted_at)
+  end
+
 
   def groups_users(members) do
     %{


### PR DESCRIPTION
Group members index endpoint has been rewritten to have the same behaviour as other many-many relationship endpoints.