### PR TITLE
[API 127] Increase default search distance

### DIFF
--- a/web/controllers/groups_controller.ex
+++ b/web/controllers/groups_controller.ex
@@ -271,7 +271,7 @@ defmodule Thegm.GroupsController do
 
     {meters, errors} = case params["meters"] do
       nil ->
-        {80467, errors}
+        {40075000, errors}
       temp ->
         {meters, _} = Float.parse(temp)
         errors = cond do


### PR DESCRIPTION
It has been increased to the circumference of the earth... We may have to revert this (or at least take it back a bit) once we actually have good group density.